### PR TITLE
Fix RemovedInDjango19Warnings when using Django >= 1.7

### DIFF
--- a/django_cassandra_engine/management/commands/sync_cassandra.py
+++ b/django_cassandra_engine/management/commands/sync_cassandra.py
@@ -27,7 +27,7 @@ class Command(NoArgsCommand):
         dispatcher events.
         """
 
-        from django.utils.importlib import import_module
+        from importlib import import_module
 
         for app_name in settings.INSTALLED_APPS:
             try:

--- a/django_cassandra_engine/utils.py
+++ b/django_cassandra_engine/utils.py
@@ -55,10 +55,10 @@ def get_installed_apps():
     """
     Return list of all installed apps
     """
-
     if django.VERSION >= (1, 7):
         from django.apps import apps
-        return apps.get_apps()
+        return [a.models_module for a in apps.get_app_configs()
+                if a.models_module is not None]
     else:
         from django.db import models
         return models.get_apps()


### PR DESCRIPTION
Replaces few cases where deprecated Django methods were used. Insted use non-deprecated Django stuff and Python core module `importlib`.