### PR TITLE
Fix for the timeout setting not working

### DIFF
--- a/django_cassandra_engine/connection.py
+++ b/django_cassandra_engine/connection.py
@@ -68,6 +68,8 @@ class CassandraConnection(object):
                 setattr(Session, option, value)
             connection.setup(self.hosts, self.keyspace,
                              **self.connection_options)
+            if(self.session_options.has_key('default_timeout')):
+                connection.session.default_timeout = self.session_options['default_timeout']
             self.session = connection.get_session()
             self.cluster = connection.get_cluster()
 


### PR DESCRIPTION
For our project, we need to make such a setting work:

```'session': {
  'default_timeout': 100,
  'default_fetch_size': None
}```

Since it did not work, played with code to figure out that we need to manually assign this to the session. This commit is a working change.