### PR TITLE
Replace NoArgsCommand with BaseCommand to accommodate 1.10 upgrade

### DIFF
--- a/django_cassandra_engine/management/commands/sync_cassandra.py
+++ b/django_cassandra_engine/management/commands/sync_cassandra.py
@@ -35,12 +35,16 @@ def emit_post_migrate_signal(verbosity, interactive, db):
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option('--database', action='store', dest='database',
-                    default=None, help='Nominates a database to synchronize.'),
-    )
-
     help = 'Sync Cassandra database(s)'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--database',
+            action='store',
+            dest='database',
+            default=None,
+            help='Nominates a database to synchronize.',
+        )
 
     @staticmethod
     def _import_management():

--- a/django_cassandra_engine/management/commands/sync_cassandra.py
+++ b/django_cassandra_engine/management/commands/sync_cassandra.py
@@ -1,7 +1,7 @@
 from optparse import make_option
 
 import django
-if django.__version__ >= '1.10':
+if django.VERSION[0:2] >= (1, 10):
     from django.core.management.base import BaseCommand, CommandError
 else:
     from django.core.management.base import NoArgsCommand as BaseCommand, CommandError

--- a/django_cassandra_engine/management/commands/sync_cassandra.py
+++ b/django_cassandra_engine/management/commands/sync_cassandra.py
@@ -1,6 +1,11 @@
 from optparse import make_option
 
-from django.core.management.base import NoArgsCommand, CommandError
+import django
+if django.__version__ >= '1.10':
+    from django.core.management.base import BaseCommand, CommandError
+else:
+    from django.core.management.base import NoArgsCommand as BaseCommand, CommandError
+
 from django.db import connections
 from django.conf import settings
 
@@ -29,8 +34,8 @@ def emit_post_migrate_signal(verbosity, interactive, db):
             using=db)
 
 
-class Command(NoArgsCommand):
-    option_list = NoArgsCommand.option_list + (
+class Command(BaseCommand):
+    option_list = BaseCommand.option_list + (
         make_option('--database', action='store', dest='database',
                     default=None, help='Nominates a database to synchronize.'),
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cassandra-driver==3.5.0
-Django<=1.10
+Django<1.11
 six>=1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cassandra-driver==3.5.0
-Django<1.10
+Django<=1.10
 six>=1.6

--- a/tox.ini
+++ b/tox.ini
@@ -28,5 +28,5 @@ deps =
 
 [testenv:django110]
 deps =
-    django>=1.10
+    django<1.11
     {[base]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django{17,18,19}
+envlist = django{17,18,19,110}
 
 [base]
 deps = nose
@@ -24,4 +24,9 @@ deps =
 [testenv:django19]
 deps =
     django>=1.9, <1.10
+    {[base]deps}
+
+[testenv:django110]
+deps =
+    django>=1.10
     {[base]deps}


### PR DESCRIPTION
Hey @r4fek - you may already be working on this, but in case you're not, this PR allows <code>django-cassandra-engine</code> to run in Django 1.10 where <code>NoArgsCommand</code> is deprecated. <a href="https://docs.djangoproject.com/es/1.9/internals/deprecation/">The docs recommend using <code>BaseCommand</code> instead.</a>