### PR TITLE
pass on SystemError in sync_cassandra.Command._import_module

### DIFF
--- a/django_cassandra_engine/management/commands/sync_cassandra.py
+++ b/django_cassandra_engine/management/commands/sync_cassandra.py
@@ -41,6 +41,10 @@ class Command(BaseCommand):
         for app_name in settings.INSTALLED_APPS:
             try:
                 import_module('.management', app_name)
+            except SystemError:
+                # We get SystemError if INSTALLED_APPS contains the
+                # name of a class rather than a module
+                pass
             except ImportError as exc:
                 # This is slightly hackish. We want to ignore ImportErrors
                 # if the "management" module itself is missing -- but we don't


### PR DESCRIPTION
If INSTALLED_APPS contains the name of a class rather than the name of
a module, importlib.import_module raises SystemError. This commit adds
code to ignore SystemError.

If this looks OK, I will create test case.