### PR TITLE
Loosen up requirements.txt for Django version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cassandra-driver==3.6.0
-Django>=1.9,<1.11
+Django>=1.7,<1.11
 six>=1.6
 djangorestframework


### PR DESCRIPTION
The current requirements also install a newer version of Django when installing Django Cassandra Engine with Django < 1.9.

Requirements should respect the installed Django version if it is among supported Django versions and not install a newer version. 

----- 
I just created this PR because according to documentation Django >= 1.6 is supported.

But it seems that that the tests are not running for older versions anymore. If Django <= 1.9 are not supported anymore then this PR is unnecessary.