### PR TITLE
Support allow_migrate in database router

### DIFF
--- a/django_cassandra_engine/base/introspection.py
+++ b/django_cassandra_engine/base/introspection.py
@@ -6,7 +6,7 @@ if django.VERSION[0:2] >= (1, 8):
 else:
     from django.db.backends import BaseDatabaseIntrospection
 
-from django_cassandra_engine.utils import get_installed_apps, get_cql_models
+from django_cassandra_engine.utils import get_installed_apps, get_cql_models, get_app_label
 
 
 class CassandraDatabaseIntrospection(BaseDatabaseIntrospection):
@@ -26,7 +26,7 @@ class CassandraDatabaseIntrospection(BaseDatabaseIntrospection):
         apps = get_installed_apps()
         keyspace = self.connection.connection.keyspace
         for app in apps:
-            self._cql_models[app.__name__] = get_cql_models(app,
+            self._cql_models[get_app_label(app)] = get_cql_models(app,
                                                             keyspace=keyspace)
 
     @property

--- a/django_cassandra_engine/utils.py
+++ b/django_cassandra_engine/utils.py
@@ -2,7 +2,7 @@ import inspect
 from cassandra import cqlengine
 import django
 from django.conf import settings
-
+from django.apps.config import MODELS_MODULE_NAME
 
 class CursorWrapper(object):
     """
@@ -137,3 +137,23 @@ def get_engine_from_db_alias(db_alias):
     """
 
     return settings.DATABASES.get(db_alias, {}).get('ENGINE', None)
+
+def get_app_label(model_module):
+    """
+
+    @param model_module:
+    @return:
+    """
+    package_components = model_module.__name__.split('.')
+    package_components.reverse()  # find the last occurrence of 'models'
+    try:
+        app_label_index = package_components.index(MODELS_MODULE_NAME) + 1
+    except ValueError:
+        app_label_index = 1
+    try:
+        return package_components[app_label_index]
+    except IndexError:
+        raise ImproperlyConfigured(
+            'Unable to detect the app label for model "%s." '
+            % (model_module.__name__)
+        )


### PR DESCRIPTION
Support multi Cassandra database by using allow_migrate methods in database router
Can define more than 1 Cassandra database

```
 'cassandra1': {
        'ENGINE': 'django_cassandra_engine',
        'NAME': 'keyspace1',
        'USER': CASSANDRA_USER_NAME,
        'PASSWORD': CASSANDRA_PASSWORD,
        'HOST': ['192.168.33.20', '192.168.33.30'],
        'OPTIONS': {
            'replication': {
                'strategy_class': 'SimpleStrategy',
                'replication_factor': 3
            },
            'connection': {
                'consistency': ConsistencyLevel.LOCAL_QUORUM,
                'retry_connect': True
            },
            'session': {
                'default_timeout': 10,
                'default_fetch_size': 10000
            }
        }
    },
    'cassandra2': {
        'ENGINE': 'django_cassandra_engine',
        'NAME': "keyspace2",
        'USER': CASSANDRA_USER_NAME,
        'PASSWORD': CASSANDRA_PASSWORD,
        'HOST': ['192.168.33.20', '192.168.33.30'],
        'OPTIONS': {
            'replication': {
                'strategy_class': 'SimpleStrategy',
                'replication_factor': 3
            },
            'connection': {
                'consistency': ConsistencyLevel.LOCAL_QUORUM,
                'retry_connect': True
            },
            'session': {
                'default_timeout': 10,
                'default_fetch_size': 10000
            }
        }
    }
```

And define database router
`DATABASE_ROUTERS = ['test.apps.common.router.db_router.DatabaseRouter']`

```
class DatabaseRouter(object):

    CASSANDRA_APPS = ['app1', 'app2']
    CASSANDRA_ANALYTICS_APP = ['app3']

    CASSANDRA_DB = 'cassandra1'
    CAS_ANALYTICS_DB = 'cassandra2'

    def db_for_read(self, model, **hints):
        # Specify target database
        pass

    def db_for_write(self, model, **hints):
        # Specify target database with field in_db in model's Meta class
        pass

    def allow_migrate(self, db, app_label, model_name=None, **hints):
        """
        Make sure correct app is migratable within specific database
        """

        if app_label in self.CASSANDRA_APPS:
            return db == self.CASSANDRA_DB
        elif app_label in self.CASSANDRA_ANALYTICS_APP:
            return db == self.CAS_ANALYTICS_DB
        return None
```

And can use `python manage.py syncdb --database cassandra1`
or `python manage.py syncdb --database cassandra2`
