### PR TITLE
Update code to match Django 1.10.3

### DIFF
--- a/django_cassandra_engine/apps.py
+++ b/django_cassandra_engine/apps.py
@@ -35,10 +35,8 @@ def construct_instance(form, instance, fields=None, exclude=None):
             field_has_default = f.has_default
         # cqlengine support logic end
 
-        if (field_has_default and form.add_prefix(f.name) not in form.data and
-                not getattr(form[f.name].field.widget,
-                            'dont_use_model_field_default_for_empty_data',
-                            False)):
+        if (field_has_default and
+                form[f.name].field.widget.value_omitted_from_data(form.data, form.files, form.add_prefix(f.name))):
             continue
         # Defer saving file-type fields until after the other fields, so a
         # callable upload_to can use the values from other fields.

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
 [testenv]
 commands = python {toxinidir}/testproject/runtests.py
 deps =
-       django110: Django==1.10
+       django110: Django==1.10.3
        djangomaster: https://github.com/django/django/archive/master.tar.gz
        mock==1.0.1
        freezegun==0.3.6


### PR DESCRIPTION
The property dont_use_model_field_default_for_empty_data is removed in Django 1.10.2 ->

This made it impossible to uncheck and save BooleanFields in forms.

See https://code.djangoproject.com/ticket/27433 for reference