### PR TITLE
Add dse-driver support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 
 sudo: false
 
+dist: precise
+
 services: cassandra
 
 env:

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ All tools you need to start your journey with Apache Cassandra and Django Framew
 
 ## Features ##
 
-* integration with latest `python-driver` from DataStax
-* working `flush`, `migrate`, `sync_cassandra`, `inspectdb` and 
+* integration with latest `python-driver` and optionally `dse-driver` from DataStax
+* working `flush`, `migrate`, `sync_cassandra`, `inspectdb` and
   `dbshell` commands
 * support for creating/destroying test database
 * accepts all `Cqlengine` and `cassandra.cluster.Cluster` connection options
@@ -28,7 +28,7 @@ All tools you need to start your journey with Apache Cassandra and Django Framew
 Recommended installation:
 
     pip install django-cassandra-engine
-  
+
 ## Basic Usage ##
 
 1. Add `django_cassandra_engine` to `INSTALLED_APPS` in your `settings.py` file:
@@ -55,11 +55,11 @@ Recommended installation:
 3. Define some model:
 
         # myapp/models.py
-        
+
         import uuid
         from cassandra.cqlengine import columns
         from django_cassandra_engine.models import DjangoCassandraModel
-        
+
         class ExampleModel(DjangoCassandraModel):
             example_id    = columns.UUID(primary_key=True, default=uuid.uuid4)
             example_type  = columns.Integer(index=True)

--- a/django_cassandra_engine/apps.py
+++ b/django_cassandra_engine/apps.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import, unicode_literals
+
 import os
 
 from django.apps import AppConfig as DjangoAppConfig
-import cassandra.cqlengine.columns
+
+from .compat import columns
 
 
 class CallableBool:
@@ -42,7 +44,7 @@ def has_default(self):
     return CallableBool(self.default is not None)
 
 # monkey patch Column.has_default to be able to use function call too
-cassandra.cqlengine.columns.Column.has_default = property(has_default)
+columns.Column.has_default = property(has_default)
 
 if os.getenv('CQLENG_ALLOW_SCHEMA_MANAGEMENT') is None:
     os.environ['CQLENG_ALLOW_SCHEMA_MANAGEMENT'] = '1'

--- a/django_cassandra_engine/base/creation.py
+++ b/django_cassandra_engine/base/creation.py
@@ -1,9 +1,7 @@
-from cassandra.cqlengine.management import (
-    create_keyspace_simple,
-    drop_keyspace
-)
-
 import django
+
+from ..compat import create_keyspace_simple, drop_keyspace
+
 if django.VERSION[0:2] >= (1, 8):
     from django.db.backends.base.creation import BaseDatabaseCreation
 else:

--- a/django_cassandra_engine/compat.py
+++ b/django_cassandra_engine/compat.py
@@ -1,0 +1,28 @@
+"""Handle package compatibility."""
+
+try:
+    from dse import cqlengine
+    from dse.cluster import Session
+    from dse.cqlengine import columns, connection, CQLEngineException, query, management
+    from dse.auth import PlainTextAuthProvider
+    from dse.cqlengine.management import create_keyspace_simple, drop_keyspace
+    from dse.cqlengine.models import (
+        ModelMetaClass, ModelException, ColumnDescriptor,
+        ModelDefinitionException, BaseModel, Model
+    )
+    from dse.util import OrderedDict
+except ImportError:
+    try:
+        from cassandra import cqlengine
+        from cassandra.cluster import Session
+        from cassandra.cqlengine import columns, connection, CQLEngineException, query, management
+        from cassandra.auth import PlainTextAuthProvider
+        from cassandra.cqlengine.management import create_keyspace_simple, drop_keyspace
+        from cassandra.cqlengine.models import (
+            ModelMetaClass, ModelException, ColumnDescriptor,
+            ModelDefinitionException, BaseModel, Model
+        )
+        from cassandra.util import OrderedDict
+    except ImportError:
+            raise ImportError('You must install either dse-driver or '
+                              + 'cassandra-driver!')

--- a/django_cassandra_engine/connection.py
+++ b/django_cassandra_engine/connection.py
@@ -1,8 +1,7 @@
 from threading import Lock
 
-from cassandra.cluster import Session
-from cassandra.cqlengine import connection, CQLEngineException
-from cassandra.auth import PlainTextAuthProvider
+from .compat import (CQLEngineException, PlainTextAuthProvider, Session,
+                     connection)
 
 
 class Cursor(object):

--- a/django_cassandra_engine/management/commands/sync_cassandra.py
+++ b/django_cassandra_engine/management/commands/sync_cassandra.py
@@ -1,12 +1,10 @@
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connections
-from django.conf import settings
-
-from cassandra.cqlengine import management
-from cassandra.cqlengine.models import Model
-
 from django_cassandra_engine.models import DjangoCassandraModel
 from django_cassandra_engine.utils import get_engine_from_db_alias
+
+from ...compat import Model, management
 
 
 class Command(BaseCommand):

--- a/django_cassandra_engine/models/__init__.py
+++ b/django_cassandra_engine/models/__init__.py
@@ -14,14 +14,10 @@ from django.core import validators
 from django.db.models.base import ModelBase
 from django.utils.translation import ugettext_lazy as _
 from django.db.models import options
-from cassandra.cqlengine import query
-from cassandra.cqlengine import columns
-from cassandra.cqlengine.models import (
-    ModelMetaClass, ModelException, ColumnDescriptor,
-    ModelDefinitionException, BaseModel
-)
-from cassandra.util import OrderedDict
 
+from ..compat import (BaseModel, ColumnDescriptor, ModelDefinitionException,
+                      ModelException, ModelMetaClass, OrderedDict, columns,
+                      query)
 from .constants import ORDER_BY_WARN, ORDER_BY_ERROR_HELP, PK_META_MISSING_HELP
 from . import django_field_methods
 from . import django_model_methods

--- a/django_cassandra_engine/rest/serializers.py
+++ b/django_cassandra_engine/rest/serializers.py
@@ -2,16 +2,14 @@ import warnings
 
 from django.utils.text import capfirst
 from rest_framework import serializers
-from rest_framework.serializers import (
-    CharField, ChoiceField, ModelField, models, postgres_fields)
-from rest_framework.utils.field_mapping import (
-    NUMERIC_FIELD_TYPES,
-    ClassLookupDict,
-    DecimalValidator,
-    needs_label,
-    validators
-)
-from cassandra.cqlengine import columns
+from rest_framework.serializers import (CharField, ChoiceField, ModelField,
+                                        models, postgres_fields)
+from rest_framework.utils.field_mapping import (NUMERIC_FIELD_TYPES,
+                                                ClassLookupDict,
+                                                DecimalValidator, needs_label,
+                                                validators)
+
+from ..compat import columns
 
 
 class DjangoCassandraModelSerializer(serializers.ModelSerializer):

--- a/django_cassandra_engine/sessions/models.py
+++ b/django_cassandra_engine/sessions/models.py
@@ -1,5 +1,4 @@
-from cassandra.cqlengine.models import Model
-from cassandra.cqlengine import columns
+from ..compat import Model, columns
 
 
 class AbstractBaseSession(Model):

--- a/django_cassandra_engine/utils.py
+++ b/django_cassandra_engine/utils.py
@@ -1,7 +1,9 @@
 import inspect
-from cassandra import cqlengine
+
 import django
 from django.conf import settings
+
+from .compat import cqlengine
 
 
 class CursorWrapper(object):


### PR DESCRIPTION
The goal of this PR is to add support for using the `dse-driver` package in lieu of `cassandra-driver` by using a `compat.py` file to handle fallback importing.

Addresses #97 