### PR TITLE
Fix #99 CassandraDatabaseSchemaEditor.create_model

### DIFF
--- a/django_cassandra_engine/base/schema.py
+++ b/django_cassandra_engine/base/schema.py
@@ -20,7 +20,7 @@ class CassandraDatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                 MigrationSchemaMissing as Exc)
         except ImportError:
             from django.core.exceptions import ImproperlyConfigured as Exc
-        raise Exception('No schema for cassandra database')
+        raise Exc('No schema for cassandra database')
 
     def delete_model(self, model):
         pass


### PR DESCRIPTION
Hello @r4fek !
I see you changed `django_cassandra_engine/base/schema.py` in commit a638a6c1237f6fc22e9e73262775204ea5fed496 .

https://github.com/r4fek/django-cassandra-engine/blob/a638a6c1237f6fc22e9e73262775204ea5fed496/django_cassandra_engine/base/schema.py#L23

Add this caused issue #99 (Exception: No schema for cassandra database).

Is this change for some reason?
