### PR TITLE
Allow "schema_metadata_enabled" set to False in the connection options

### DIFF
--- a/django_cassandra_engine/base/__init__.py
+++ b/django_cassandra_engine/base/__init__.py
@@ -149,6 +149,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         # keyspace doesn't exist.
         from cassandra.cqlengine import connection
         keyspace = self.settings_dict['NAME']
+        if not connection.cluster.schema_metadata_enabled and \
+                keyspace not in connection.cluster.metadata.keyspaces:
+            connection.cluster.refresh_schema_metadata()
+
         connection.cluster.metadata.keyspaces[keyspace]
         return CursorWrapper(self.connection.cursor(), self)
 

--- a/django_cassandra_engine/base/introspection.py
+++ b/django_cassandra_engine/base/introspection.py
@@ -58,6 +58,10 @@ class CassandraDatabaseIntrospection(BaseDatabaseIntrospection):
 
         connection = self.connection.connection
         keyspace_name = connection.keyspace
+        if not connection.cluster.schema_metadata_enabled and \
+                keyspace_name not in connection.cluster.metadata.keyspaces:
+            connection.cluster.refresh_schema_metadata()
+
         keyspace = connection.cluster.metadata.keyspaces[keyspace_name]
         return keyspace.tables
 

--- a/testproject/runtests.py
+++ b/testproject/runtests.py
@@ -47,6 +47,8 @@ def main():
         'settings.secondary_cassandra')
     multi_cassandra = import_module(
         'settings.multi_cassandra')
+    metadata_disabled = import_module(
+        'settings.metadata_disabled')
 
     if django.VERSION[0:2] >= (1, 7):
         django.setup()
@@ -55,6 +57,7 @@ def main():
     run_tests(default_only_cass)
     run_tests(secondary_cassandra)
     run_tests(multi_cassandra)
+    run_tests(metadata_disabled)
     sys.exit(0)
 
 

--- a/testproject/settings/metadata_disabled.py
+++ b/testproject/settings/metadata_disabled.py
@@ -1,0 +1,35 @@
+from .base import *
+
+# Database
+# https://docs.djangoproject.com/en/1.6/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    },
+    'cassandra': {
+        'ENGINE': 'django_cassandra_engine',
+        'NAME': 'db',
+        'USER': 'user',
+        'PASSWORD': 'pass',
+        'TEST_NAME': 'test_db',
+        'HOST': '127.0.0.1',
+        'OPTIONS': {
+            'replication': {
+                'strategy_class': 'SimpleStrategy',
+                'replication_factor': 1,
+            },
+            'connection': {
+                'schema_metadata_enabled': False,
+                'retry_connect': True,
+                'consistency': ConsistencyLevel.ALL
+            },
+            'session': {
+                'default_timeout': 15
+            }
+        }
+    }
+}
+
+INSTALLED_APPS = BASE_APPS + ['app', 'common', 'model_meta']


### PR DESCRIPTION
This patch allows the `schema_metadata_enabled` ([link to the doc](https://datastax.github.io/python-driver/api/cassandra/cluster.html#cassandra.cluster.Cluster.schema_metadata_enabled)) connection option set to `False` in the database settings.

Set this option to `False` is useful on large production environment with many client applications starting at the same time. It reduces loads on Cassandra server and speeds up the Django startup.

Note: When the `schema_metadata_enabled` option is set to `False`, the `sync_cassandra` command will not work. One should run the `sync_cassandra` command with a different settings file where `schema_metadata_enabled` is set to `True` (the default).