### PR TITLE
fix python manage.py test cannot use correct db options

### DIFF
--- a/django_cassandra_engine/connection.py
+++ b/django_cassandra_engine/connection.py
@@ -5,7 +5,7 @@ from .compat import (
     Session,
     connection,
 )
-
+import copy
 
 class Cursor(object):
     def __init__(self, connection):
@@ -44,7 +44,7 @@ class CassandraConnection(object):
         self.keyspace = options.get('NAME')
         self.user = options.get('USER')
         self.password = options.get('PASSWORD')
-        self.options = options.get('OPTIONS', {})
+        self.options = copy.deepcopy(options.get('OPTIONS', {}))
         self.cluster_options = self.options.get('connection', {})
         self.session_options = self.options.get('session', {})
         self.connection_options = {


### PR DESCRIPTION
I found that in this function, the pop operation on settings dict may change the settings in other objects. As a result, 'lazy_connect', 'retry_connect' and 'consistency' options will become invalid after the first connection establishing. During the Django testing, Cassandra connection settings are ignored makes me continually encounter ConsistencyLevel issues. Here are some logs during a Django test
```
{'ENGINE': 'django_cassandra_engine', 'NAME': '***', 'TEST': {'NAME': '***', 'CHARSET': None, 'COLLATION': None, 'MIRROR': None}, 'HOST': '***', 'OPTIONS': {'replication': {'strategy_class': 'SimpleStrategy', 'replication_factor': 3}, 'connection': {'consistency': 1}}, 'ATOMIC_REQUESTS': False, 'AUTOCOMMIT': True, 'CONN_MAX_AGE': 0, 'TIME_ZONE': None, 'USER': '', 'PASSWORD': '', 'PORT': ''}
{'ENGINE': 'django_cassandra_engine', 'NAME': '***', 'TEST': {'NAME': '***', 'CHARSET': None, 'COLLATION': None, 'MIRROR': None}, 'HOST': '***', 'OPTIONS': {'replication': {'strategy_class': 'SimpleStrategy', 'replication_factor': 3}, 'connection': {}}, 'ATOMIC_REQUESTS': False, 'AUTOCOMMIT': True, 'CONN_MAX_AGE': 0, 'TIME_ZONE': None, 'USER': '', 'PASSWORD': '', 'PORT': ''}
Creating test database for alias 'default'...
Creating test database for alias 'cassandra'...
{'ENGINE': 'django_cassandra_engine', 'NAME': '***', 'TEST': {'NAME': '***', 'CHARSET': None, 'COLLATION': None, 'MIRROR': None}, 'HOST': '***', 'OPTIONS': {'replication': {'strategy_class': 'SimpleStrategy'}, 'connection': {}}, 'ATOMIC_REQUESTS': False, 'AUTOCOMMIT': True, 'CONN_MAX_AGE': 0, 'TIME_ZONE': None, 'USER': '', 'PASSWORD': '', 'PORT': ''}
{'ENGINE': 'django_cassandra_engine', 'NAME': '***', 'TEST': {'NAME': '***', 'CHARSET': None, 'COLLATION': None, 'MIRROR': None}, 'HOST': '***', 'OPTIONS': {'replication': {'strategy_class': 'SimpleStrategy'}, 'connection': {}}, 'ATOMIC_REQUESTS': False, 'AUTOCOMMIT': True, 'CONN_MAX_AGE': 0, 'TIME_ZONE': None, 'USER': '', 'PASSWORD': '', 'PORT': ''}
```
I am not sure whether this is by design since 'replication_factor' is also popped at somewhere else, but I think modifying external objects through this is confusing.