### PR TITLE
Multiple testing processes with xdist all try to create the same runtime keyspace

### DIFF
--- a/django_cassandra_engine/base/creation.py
+++ b/django_cassandra_engine/base/creation.py
@@ -1,6 +1,5 @@
 import django
 from cassandra.cqlengine.connection import set_default_connection
-from cassandra import AlreadyExists
 
 from django_cassandra_engine.utils import get_default_cassandra_connection
 from ..compat import create_keyspace_simple, drop_keyspace
@@ -54,13 +53,10 @@ class CassandraDatabaseCreation(BaseDatabaseCreation):
         replication_opts = options.get('replication', {})
         replication_factor = replication_opts.pop('replication_factor', 1)
 
-        try:
-            create_keyspace_simple(
-                self.connection.settings_dict['NAME'],
-                replication_factor,
-                connections=[self.connection.alias])
-        except AlreadyExists:
-            pass
+        create_keyspace_simple(
+            test_database_name,
+            replication_factor,
+            connections=[self.connection.alias])
 
         settings.DATABASES[self.connection.alias]["NAME"] = test_database_name
         self.connection.settings_dict["NAME"] = test_database_name

--- a/django_cassandra_engine/base/creation.py
+++ b/django_cassandra_engine/base/creation.py
@@ -1,5 +1,6 @@
 import django
 from cassandra.cqlengine.connection import set_default_connection
+from cassandra import AlreadyExists
 
 from django_cassandra_engine.utils import get_default_cassandra_connection
 from ..compat import create_keyspace_simple, drop_keyspace
@@ -53,10 +54,13 @@ class CassandraDatabaseCreation(BaseDatabaseCreation):
         replication_opts = options.get('replication', {})
         replication_factor = replication_opts.pop('replication_factor', 1)
 
-        create_keyspace_simple(
-            self.connection.settings_dict['NAME'],
-            replication_factor,
-            connections=[self.connection.alias])
+        try:
+            create_keyspace_simple(
+                self.connection.settings_dict['NAME'],
+                replication_factor,
+                connections=[self.connection.alias])
+        except AlreadyExists:
+            pass
 
         settings.DATABASES[self.connection.alias]["NAME"] = test_database_name
         self.connection.settings_dict["NAME"] = test_database_name


### PR DESCRIPTION
Found a bug when using pytest-django and django-cassandra-engine with pytest-xdist for multi-concurrency test execution.

The create_test_db method is creating the keyspace for the runtime database instead of the test database if it doesn't exist.
This causes problems when testing with multiple concurrency because each testing process attempts to create the runtime database leading to all but one of the processes failing.

In truth you don't need to create the test database either since the sync_cassandra management command deals with that.