### PR TITLE
Using application registry api to get app names

### DIFF
--- a/django_cassandra_engine/management/commands/sync_cassandra.py
+++ b/django_cassandra_engine/management/commands/sync_cassandra.py
@@ -28,27 +28,8 @@ class Command(BaseCommand):
 
         from importlib import import_module
 
-        for app_name in settings.INSTALLED_APPS:
-            try:
-                import_module('.management', app_name)
-            except SystemError:
-                # We get SystemError if INSTALLED_APPS contains the
-                # name of a class rather than a module
-                pass
-            except ImportError as exc:
-                # This is slightly hackish. We want to ignore ImportErrors
-                # if the "management" module itself is missing -- but we don't
-                # want to ignore the exception if the management module exists
-                # but raises an ImportError for some reason. The only way we
-                # can do this is to check the text of the exception. Note that
-                # we're a bit broad in how we check the text, because different
-                # Python implementations may not use the same text.
-                # CPython uses the text "No module named management"
-                # PyPy uses "No module named myproject.myapp.management"
-                msg = exc.args[0]
-                if not msg.startswith('No module named') \
-                        or 'management' not in msg:
-                    raise
+        for app_config in apps.get_app_configs():
+            import_module('.management', app_config.name)
 
     def sync(self, alias):
         engine = get_engine_from_db_alias(alias)

--- a/django_cassandra_engine/management/commands/sync_cassandra.py
+++ b/django_cassandra_engine/management/commands/sync_cassandra.py
@@ -3,6 +3,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import connections
 from django_cassandra_engine.models import DjangoCassandraModel
 from django_cassandra_engine.utils import get_engine_from_db_alias
+from django.apps import apps
 
 from ...compat import Model, management
 


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/un1t/django-cleanup/issues/48