### PR TITLE
Support cloud cred bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ Recommended installation:
 4. Run `./manage.py sync_cassandra`
 5. Done!
 
+## Connect to Cassandra with a Cloud Config bundle ##
+To connect to a hosted Cassandra cluster that provides a secure connection bundle (ex. DataStax Astra) change the `DATABASES` setting of your settings.py:
+
+        DATABASES = {
+            'default': {
+                'ENGINE': 'django_cassandra_engine',
+                'NAME': 'db_name',
+                'TEST_NAME': 'db_name',
+                'USER': username,
+                'PASSWORD': password,
+                'OPTIONS': {
+                    'connection': {
+                        'cloud': {
+                            'secure_connect_bundle': '/path/to/secure/bundle.zip'
+                        },
+                    }
+                }
+            }
+        }
+
 ## Documentation ##
 
 The documentation can be found online [here](http://r4fek.github.io/django-cassandra-engine/).

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ All tools you need to start your journey with Apache Cassandra and Django Framew
 * storing sessions in Cassandra
 * working django forms
 * usable admin panel with Cassandra models
+* support DataStax Astra cloud hosted Cassandra
 
 ## Installation ##
 

--- a/django_cassandra_engine/compat.py
+++ b/django_cassandra_engine/compat.py
@@ -2,7 +2,7 @@
 
 try:
     from dse import cqlengine
-    from dse.cluster import Session
+    from dse.cluster import Session, Cluster
     from dse.cqlengine import columns, connection, CQLEngineException, query, management
     from dse.auth import PlainTextAuthProvider
     from dse.cqlengine.management import create_keyspace_simple, drop_keyspace
@@ -14,7 +14,7 @@ try:
 except ImportError:
     try:
         from cassandra import cqlengine
-        from cassandra.cluster import Session
+        from cassandra.cluster import Session, Cluster
         from cassandra.cqlengine import columns, connection, CQLEngineException, query, management
         from cassandra.auth import PlainTextAuthProvider
         from cassandra.cqlengine.management import create_keyspace_simple, drop_keyspace

--- a/django_cassandra_engine/connection.py
+++ b/django_cassandra_engine/connection.py
@@ -4,8 +4,8 @@ from .compat import (
     PlainTextAuthProvider,
     Session,
     connection,
+    Cluster
 )
-
 
 class Cursor(object):
     def __init__(self, connection):
@@ -84,14 +84,22 @@ class CassandraConnection(object):
 
             for option, value in self.session_options.items():
                 setattr(Session, option, value)
-
-            connection.register_connection(
-                self.alias,
-                hosts=self.hosts,
-                default=self.default,
-                cluster_options=self.cluster_options,
-                **self.connection_options
-            )
+            if 'cloud' in self.cluster_options:
+                cluster = Cluster(**self.cluster_options)
+                session = cluster.connect()
+                connection.register_connection(
+                    self.alias,
+                    default=self.default,
+                    session=session
+                )
+            else:
+                connection.register_connection(
+                    self.alias,
+                    hosts=self.hosts,
+                    default=self.default,
+                    cluster_options=self.cluster_options,
+                    **self.connection_options
+                )   
 
     @property
     def cluster(self):


### PR DESCRIPTION
I've made a few adjustments to allow connections to Cassandra hosted in the DataStax Astra service.  Please take a look and let me know if there is anything else required or you need further information.

Astra supports free developer instances that could be great when working with Cassandra backed Django.