### PR TITLE
fix(command/dbshell): Avoid raise TypeError when django-3.2 pass `opt…

### DIFF
--- a/django_cassandra_engine/base/client.py
+++ b/django_cassandra_engine/base/client.py
@@ -6,7 +6,7 @@ from django.db.backends.base.client import BaseDatabaseClient
 class CassandraDatabaseClient(BaseDatabaseClient):
     executable_name = 'cqlsh'
 
-    def runshell(self):
+    def runshell(self, *args, **kwargs):
         settings_dict = self.connection.settings_dict
         args = [self.executable_name]
         if settings_dict['HOST']:


### PR DESCRIPTION
…ions['parameters']`

Version:
django==3.2.10
django-cassandra-engine==1.6.3

Reproduce:
`python manage.py dbshell`

Error message:
```
$ python manage.py dbshell --database cassandra
Traceback (most recent call last):
  File "manage.py", line 22, in <module>
    main()
  File "manage.py", line 18, in main
    execute_from_command_line(sys.argv)
  File "/Users/icycandle/.pyenv/versions/django_chat/lib/python3.7/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/Users/icycandle/.pyenv/versions/django_chat/lib/python3.7/site-packages/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/icycandle/.pyenv/versions/django_chat/lib/python3.7/site-packages/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/icycandle/.pyenv/versions/django_chat/lib/python3.7/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/Users/icycandle/.pyenv/versions/django_chat/lib/python3.7/site-packages/django/core/management/commands/dbshell.py", line 26, in handle
    connection.client.runshell(options['parameters'])
TypeError: runshell() takes 1 positional argument but 2 were given
```